### PR TITLE
currentColor for default fill

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-svg-symbols",
   "description": "Generate an SVG icon system (based on `<symbol>`) of a specified folder",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "author": {
     "name": "Manuel Wieser",
     "email": "office@manuelwieser.com",

--- a/tasks/svg_symbols.js
+++ b/tasks/svg_symbols.js
@@ -63,6 +63,7 @@ module.exports = function(grunt) {
 
           if (options.currentColor) {
             $('[fill]').not('[fill="none"]').attr('fill', 'currentColor');
+            $(':not([fill])').attr('fill', 'currentColor');
             $('[stroke]').not('[stroke="none"]').attr('stroke', 'currentColor');
           }
 

--- a/test/expected/current_color
+++ b/test/expected/current_color
@@ -3,6 +3,6 @@
         <path d="M77.8 17.2l-25.1 21 25 23.7c.2-.4.3-1 .3-1.4v-42c0-.5 0-1-.2-1.3zM39.5 48.7L29.7 41 4.4 65l1.2.1h67.8c.4 0 .8 0 1.2-.2L49.3 41l-9.8 7.8zM33 38.1l6.6 5.2 10-8 25.2-21c-.4-.2-.9-.3-1.3-.3H5.6c-.4 0-.9 0-1.3.2l25.3 21.2 3.3 2.7zM1.2 17L1 18.6v42c0 .5.1 1 .3 1.4l25-23.6-25-21.1z" fill="currentColor" fill-rule="evenodd"></path>
     </symbol>
     <symbol id="clock" viewBox="0 0 24 24">
-        <g stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" fill="none"><circle cx="12" cy="12" r="11"></circle><path d="M11.5 6.5V12l6 5.5"></path></g>
+        <g stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" fill="none"><circle cx="12" cy="12" r="11" fill="currentColor"></circle><path d="M11.5 6.5V12l6 5.5" fill="currentColor"></path></g>
     </symbol>
 </svg>


### PR DESCRIPTION
Apply _fill="currentColor"_ even if no fill attribute is set, because no fill attribute defaults to _fill="#000"_ by specification (https://www.w3.org/TR/SVG/painting.html#FillProperty)
